### PR TITLE
Preliminary work for input remapping feature for keyboards

### DIFF
--- a/ui/xemu-input.c
+++ b/ui/xemu-input.c
@@ -360,7 +360,6 @@ void xemu_input_rebind(const SDL_Event *ev)
     //TODO: give an order to map buttons by highlighting them on the UI
     if(ev->type == SDL_KEYDOWN){
         sdl_kbd_scancode_map[currently_remapping] = ev->key.keysym.scancode;
-        fprintf(stdout, "%d\n", ev->key.keysym.scancode);
         currently_remapping++;
         if(currently_remapping == sizeof(sdl_kbd_scancode_map)/sizeof(int)){
             is_remapping_active = false;

--- a/ui/xemu-input.c
+++ b/ui/xemu-input.c
@@ -357,51 +357,20 @@ void xemu_input_update_sdl_kbd_controller_state(ControllerState *state)
 
 void xemu_input_rebind(SDL_Event *ev)
 {
-    if(ev->type == SDL_KEYDOWN){
-        sdl_kbd_scancode_map[0] = ev->key.keysym.scancode;
-        fprintf(stdout, "%d\n", ev->key.keysym.scancode);
-        is_remapping_active = !is_remapping_active;
-    }
-    //kbd[SDL_SCANCODE_0];
-
     //TODO: give an order to map buttons by highlighting them on the UI
-    
-    /*
-    sdl_kbd_scancode_map[0] = g_config.input.keyboard_controller_scancode_map.b;
-    sdl_kbd_scancode_map[2] = g_config.input.keyboard_controller_scancode_map.x;
-    sdl_kbd_scancode_map[3] = g_config.input.keyboard_controller_scancode_map.y;
-    sdl_kbd_scancode_map[4] = g_config.input.keyboard_controller_scancode_map.dpad_left;
-    sdl_kbd_scancode_map[5] = g_config.input.keyboard_controller_scancode_map.dpad_up;
-    sdl_kbd_scancode_map[6] = g_config.input.keyboard_controller_scancode_map.dpad_right;
-    sdl_kbd_scancode_map[7] = g_config.input.keyboard_controller_scancode_map.dpad_down;
-    sdl_kbd_scancode_map[8] = g_config.input.keyboard_controller_scancode_map.back;
-    sdl_kbd_scancode_map[9] = g_config.input.keyboard_controller_scancode_map.start;
-    sdl_kbd_scancode_map[10] = g_config.input.keyboard_controller_scancode_map.white;
-    sdl_kbd_scancode_map[11] = g_config.input.keyboard_controller_scancode_map.black;
-    sdl_kbd_scancode_map[12] = g_config.input.keyboard_controller_scancode_map.lstick_btn;
-    sdl_kbd_scancode_map[13] = g_config.input.keyboard_controller_scancode_map.rstick_btn;
-    sdl_kbd_scancode_map[14] = g_config.input.keyboard_controller_scancode_map.guide;
-    sdl_kbd_scancode_map[15] = g_config.input.keyboard_controller_scancode_map.lstick_up;
-    sdl_kbd_scancode_map[16] = g_config.input.keyboard_controller_scancode_map.lstick_left;
-    sdl_kbd_scancode_map[17] = g_config.input.keyboard_controller_scancode_map.lstick_right;
-    sdl_kbd_scancode_map[18] = g_config.input.keyboard_controller_scancode_map.lstick_down;
-    sdl_kbd_scancode_map[19] = g_config.input.keyboard_controller_scancode_map.ltrigger;
-    sdl_kbd_scancode_map[20] = g_config.input.keyboard_controller_scancode_map.rstick_up;
-    sdl_kbd_scancode_map[21] = g_config.input.keyboard_controller_scancode_map.rstick_left;
-    sdl_kbd_scancode_map[22] = g_config.input.keyboard_controller_scancode_map.rstick_right;
-    sdl_kbd_scancode_map[23] = g_config.input.keyboard_controller_scancode_map.rstick_down;
-    sdl_kbd_scancode_map[24] = g_config.input.keyboard_controller_scancode_map.rtrigger;
-
-    */
-       
-
-    for (size_t i = 0; i < 1; i++)
-    {
-        if( (sdl_kbd_scancode_map[i] < SDL_SCANCODE_UNKNOWN) || 
-            (sdl_kbd_scancode_map[i] >= SDL_NUM_SCANCODES) ) {
-            fprintf(stderr, "WARNING: Keyboard controller map scancode out of range (%d) : Disabled\n", sdl_kbd_scancode_map[i]);
-            sdl_kbd_scancode_map[i] = SDL_SCANCODE_UNKNOWN;
+    if(ev->type == SDL_KEYDOWN){
+        sdl_kbd_scancode_map[currently_remapping] = ev->key.keysym.scancode;
+        fprintf(stdout, "%d\n", ev->key.keysym.scancode);
+        currently_remapping++;
+        if(currently_remapping == sizeof(sdl_kbd_scancode_map)/sizeof(int)){
+            is_remapping_active = false;
         }
+    }
+
+    if( (sdl_kbd_scancode_map[i] < SDL_SCANCODE_UNKNOWN) || 
+        (sdl_kbd_scancode_map[i] >= SDL_NUM_SCANCODES) ) {
+        fprintf(stderr, "WARNING: Keyboard controller map scancode out of range (%d) : Disabled\n", sdl_kbd_scancode_map[i]);
+        sdl_kbd_scancode_map[i] = SDL_SCANCODE_UNKNOWN;
     }
 } 
 

--- a/ui/xemu-input.c
+++ b/ui/xemu-input.c
@@ -355,7 +355,7 @@ void xemu_input_update_sdl_kbd_controller_state(ControllerState *state)
     if (kbd[sdl_kbd_scancode_map[24]]) state->axis[CONTROLLER_AXIS_RTRIG] = 32767;
 }
 
-void xemu_input_rebind(SDL_Event *ev)
+void xemu_input_rebind(const SDL_Event *ev)
 {
     //TODO: give an order to map buttons by highlighting them on the UI
     if(ev->type == SDL_KEYDOWN){
@@ -367,10 +367,10 @@ void xemu_input_rebind(SDL_Event *ev)
         }
     }
 
-    if( (sdl_kbd_scancode_map[i] < SDL_SCANCODE_UNKNOWN) || 
-        (sdl_kbd_scancode_map[i] >= SDL_NUM_SCANCODES) ) {
-        fprintf(stderr, "WARNING: Keyboard controller map scancode out of range (%d) : Disabled\n", sdl_kbd_scancode_map[i]);
-        sdl_kbd_scancode_map[i] = SDL_SCANCODE_UNKNOWN;
+    if( (sdl_kbd_scancode_map[currently_remapping] < SDL_SCANCODE_UNKNOWN) || 
+        (sdl_kbd_scancode_map[currently_remapping] >= SDL_NUM_SCANCODES) ) {
+        fprintf(stderr, "WARNING: Keyboard controller map scancode out of range (%d) : Disabled\n", sdl_kbd_scancode_map[currently_remapping]);
+        sdl_kbd_scancode_map[currently_remapping] = SDL_SCANCODE_UNKNOWN;
     }
 } 
 

--- a/ui/xemu-input.c
+++ b/ui/xemu-input.c
@@ -298,7 +298,9 @@ void xemu_input_process_sdl_events(const SDL_Event *event)
         }
     } else if (event->type == SDL_CONTROLLERDEVICEREMAPPED) {
         DPRINTF("Controller Remapped: %d\n", event->cdevice.which);
-    }
+    } else if (is_remapping_active){
+        xemu_input_rebind(event);
+    }  
 }
 
 void xemu_input_update_controller(ControllerState *state)
@@ -355,17 +357,15 @@ void xemu_input_update_sdl_kbd_controller_state(ControllerState *state)
 
 void xemu_input_rebind(SDL_Event *ev)
 {
-    const uint8_t *kbd = SDL_GetKeyboardState(NULL);
+    if(ev->type == SDL_KEYDOWN){
+        sdl_kbd_scancode_map[0] = ev->key.keysym.scancode;
+        fprintf(stdout, "%d\n", ev->key.keysym.scancode);
+        is_remapping_active = !is_remapping_active;
+    }
     //kbd[SDL_SCANCODE_0];
 
     //TODO: give an order to map buttons by highlighting them on the UI
-    for (size_t i = 0; i < 2; i++)
-    {
-        if (SDL_KEYDOWN == ev->type)
-        {
-            sdl_kbd_scancode_map[i] = kbd[SDL_SCANCODE_0];
-        }
-    }    
+    
     /*
     sdl_kbd_scancode_map[0] = g_config.input.keyboard_controller_scancode_map.b;
     sdl_kbd_scancode_map[2] = g_config.input.keyboard_controller_scancode_map.x;

--- a/ui/xemu-input.h
+++ b/ui/xemu-input.h
@@ -97,6 +97,7 @@ struct sdl2_console *get_scon_from_window(uint32_t window_id);
 typedef QTAILQ_HEAD(, ControllerState) ControllerStateList;
 extern ControllerStateList available_controllers;
 extern ControllerState *bound_controllers[4];
+
 extern bool is_remapping_active;
 
 #ifdef __cplusplus

--- a/ui/xemu-input.h
+++ b/ui/xemu-input.h
@@ -99,6 +99,7 @@ extern ControllerStateList available_controllers;
 extern ControllerState *bound_controllers[4];
 
 extern bool is_remapping_active;
+extern int currently_remapping;
 
 #ifdef __cplusplus
 extern "C" {

--- a/ui/xemu-input.h
+++ b/ui/xemu-input.h
@@ -112,7 +112,7 @@ void xemu_input_update_controller(ControllerState *state);
 void xemu_input_update_sdl_kbd_controller_state(ControllerState *state);
 void xemu_input_update_sdl_controller_state(ControllerState *state);
 void xemu_input_update_rumble(ControllerState *state);
-void xemu_input_rebind(SDL_Event *ev);
+void xemu_input_rebind(const SDL_Event *ev);
 ControllerState *xemu_input_get_bound(int index);
 void xemu_input_bind(int index, ControllerState *state, int save);
 int xemu_input_get_controller_default_bind_port(ControllerState *state, int start);

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -273,8 +273,6 @@ void MainMenuInputView::Draw()
     if (is_remapping_active)
     {
         ImGui::Text("Press the key you want to bind to the highlighted button");
-        SDL_Event event;
-        xemu_input_rebind(&event);
     }
 }
 

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -39,6 +39,7 @@
 
 MainMenuScene g_main_menu;
 bool is_remapping_active = false;
+int currently_remapping = 0;
 
 MainMenuTabView::~MainMenuTabView() {}
 void MainMenuTabView::Draw() {}
@@ -267,6 +268,7 @@ void MainMenuInputView::Draw()
     
     if (ImGui::IsItemClicked(ImGui::Button("Rebind Controls")))
     {
+        currently_remapping = 0;
         is_remapping_active = !is_remapping_active;
     }
 


### PR DESCRIPTION
This pull request adds a simple backbone for a input remapping feature. Only keyboard remapping is supported at the moment, and its not tested what happens when a controller is plugged in.
The configuration is lost when the emulator is restarted.